### PR TITLE
changed screen width test to a greater than check

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -5,24 +5,24 @@ var window_utils = require('sdk/window/utils');
 
 var x = 1;
 var refresh = function() {
-	var window = window_utils.getFocusedWindow();
+  var window = window_utils.getFocusedWindow();
 
-	// when we change devPixelsPerPx it also affects availWidth so we fix it
-	var width = window.screen.availWidth * x;
+  // when we change devPixelsPerPx it also affects availWidth so we fix it
+  var width = window.screen.availWidth * x;
 
-	if (width == simple_prefs.prefs['screenWidth']) {
-		var pixelRatioMapping = {
-			0: 1.5,
-			1: 2
-		};
-		x = pixelRatioMapping[simple_prefs.prefs['pixelRatio']];
-	} else {
-		x = 1;
-	}
+  if (width >= simple_prefs.prefs['screenWidth']) {
+    var pixelRatioMapping = {
+      0: 1.5,
+      1: 2
+    };
+    x = pixelRatioMapping[simple_prefs.prefs['pixelRatio']];
+  } else {
+    x = 1;
+  }
 
-	preferences.set('layout.css.devPixelsPerPx', x+'');
+  preferences.set('layout.css.devPixelsPerPx', x+'');
 
-	//console.log('width=' + width + ' x=' + x);
+  //console.log('width=' + width + ' x=' + x);
 };
 
 windows.on('activate', refresh);

--- a/package.json
+++ b/package.json
@@ -6,28 +6,28 @@
   "author": "",
   "license": "MPL 2.0",
   "version": "0.1",
-	"preferences": [{
-        "name": "screenWidth",
-        "title": "HiDPI Screen Width",
-        "description": "Automatically enable HiDPI mode when active screen width matches this value (pixels)",
-        "type": "integer",
-        "value": 2880
-    },
-	{
-		"name": "pixelRatio",
-		"title": "Pixel Ratio",
-		"description": "Pixel ratio to use when HiDPI mode is enabled",
-		"type": "menulist",
-		"value": 0,
-		"options": [
-			{
-				"value": "0",
-				"label": "1.5x"
-			},
-			{
-				"value": "1",
-				"label": "2x"
-			}
-		]
-	}]
+  "preferences": [{
+    "name": "screenWidth",
+    "title": "HiDPI Screen Width",
+    "description": "Automatically enable HiDPI mode when active screen width is greater than this value (pixels)",
+    "type": "integer",
+    "value": 2880
+  },
+  {
+    "name": "pixelRatio",
+    "title": "Pixel Ratio",
+    "description": "Pixel ratio to use when HiDPI mode is enabled",
+    "type": "menulist",
+    "value": 0,
+    "options": [
+      {
+        "value": "0",
+        "label": "1.5x"
+      },
+      {
+        "value": "1",
+        "label": "2x"
+      }
+    ]
+  }]
 }


### PR DESCRIPTION
Thanks for this handy little extension!

This is a simple PR to change the criteria for HiDPI mode to a `>=` check.  When your HiDPI scaling is 1.5 and your screen width isn't evenly divided by 1.5 (e.g. 3200, 2560), firefox will toggle between the modes with every refresh.

If you also had heterogeneous displays, (e.g. a HiDPI laptop display, a 4k display, plus an older 72 DPI monitor), this would allow you to set a threshold at which to enable scaling.
