### PR TITLE
Added kick-in reload and custom value

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -10,20 +10,14 @@ var refresh = function() {
   // when we change devPixelsPerPx it also affects availWidth so we fix it
   var width = Math.ceil(window.screen.availWidth * x);
 
-  if (width >= simple_prefs.prefs['screenWidth']) {
-    var pixelRatioMapping = {
-      0: 1.5,
-      1: 2
-    };
-    x = pixelRatioMapping[simple_prefs.prefs['pixelRatio']];
+  if (width >= simple_prefs.prefs.screenWidth) {
+    x = simple_prefs.prefs.pixelRatio / 100;
   } else {
     x = 1;
   }
-
   preferences.set('layout.css.devPixelsPerPx', x+'');
-
-  //console.log('width=' + width + ' x=' + x);
 };
 
 windows.on('activate', refresh);
 simple_prefs.on('', refresh);
+refresh();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Automatically enable and disable HiDPI (a.k.a. Retina) mode (layout.css.devPixelsPerPx) for multiple monitor setups.",
   "author": "",
   "license": "MPL 2.0",
-  "version": "1.1",
+  "version": "1.2",
   "preferences": [{
     "name": "screenWidth",
     "title": "HiDPI Screen Width",
@@ -16,18 +16,8 @@
   {
     "name": "pixelRatio",
     "title": "Pixel Ratio",
-    "description": "Pixel ratio to use when HiDPI mode is enabled",
-    "type": "menulist",
-    "value": 0,
-    "options": [
-      {
-        "value": "0",
-        "label": "1.5x"
-      },
-      {
-        "value": "1",
-        "label": "2x"
-      }
-    ]
+    "description": "Pixel ratio to use when HiDPI mode is enabled (for 1.75 enter 175)",
+    "type": "integer",
+    "value": 175
   }]
 }


### PR DESCRIPTION
Hei Ertug, I've done a couple of changes to your extension to solve some problem I (and some other guys who posted in the addon page) have found.
I've added a `refresh();` call right in the `main.js` so the extension is loaded at the first load, and I've changed the select option for the zoom to a integer.

It's 100 based, so for have a 1.75 zoom level the user just enters 175.

If you like, you can merge this pull request and pack the 1.2 version!

Have a nice day!