### PR TITLE
Allow extension to run in private windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "",
   "license": "MPL 2.0",
   "version": "1.2",
+  "permissions": {"private-browsing": true},
   "preferences": [{
     "name": "screenWidth",
     "title": "HiDPI Screen Width (Pixels)",


### PR DESCRIPTION
Currently, the DPI doesn't auto switch when a private window is selected, which is especially annoying if private windows are part of a user's workflow.

This could be why some people were complaining on the [extension page](https://addons.mozilla.org/en-US/firefox/addon/autohidpi/reviews/778527/) that the behavior is inconsistent.