### PR TITLE
Added the option to modify the default ratio.

### DIFF
--- a/data/panel.html
+++ b/data/panel.html
@@ -18,5 +18,11 @@
       <div style="padding: 5px; float: left;"><input type="range" id="pixelRatio" min="0.75" max="3" step="0.25" style="width: 150px;" /></div>
       <div style="clear: both;"></div>
     </div>
+    <h2>Default Ratio</h2>
+    <div style="background-color: #FFF;">
+      <div id="DefaultDisplay" style="width: 60px; margin: 5px 15px; float: left;"></div>
+      <div style="padding: 5px; float: left;"><input type="range" id="defaultRatio" min="0.75" max="3" step="0.25" style="width: 150px;" /></div>
+      <div style="clear: both;"></div>
+    </div>
   </body>
 </html>

--- a/data/panel.js
+++ b/data/panel.js
@@ -1,6 +1,8 @@
 var geometry = document.getElementById('geometry');
 var pixelRatioInput = document.getElementById('pixelRatio');
 var pixelRatioDisplay = document.getElementById('pixelRatioDisplay');
+var defaultRatioInput = document.getElementById('defaultRatio');
+var defaulRatioDisplay = document.getElementById('DefaultDisplay');
 
 pixelRatioInput.addEventListener('input', function (event) {
   pixelRatioDisplay.textContent = event.target.value + 'x';
@@ -8,6 +10,14 @@ pixelRatioInput.addEventListener('input', function (event) {
 
 pixelRatioInput.addEventListener('change', function (event) {
   self.port.emit('pixelRatioChanged', parseFloat(event.target.value));
+}, false);
+
+defaultRatioInput.addEventListener('input', function (event) {
+  defaulRatioDisplay.textContent = event.target.value + 'x';
+}, false);
+
+defaultRatioInput.addEventListener('change', function (event) {
+  self.port.emit('defaultRatioChanged', parseFloat(event.target.value));
 }, false);
 
 self.port.on('update', function (event) {

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var self = require('sdk/self');
 var storage = require('sdk/simple-storage').storage;
 var events = require('sdk/system/events');
 
-const DEFAULT_PIXEL_RATIO = 1;
+DEFAULT_PIXEL_RATIO = 1;
 const UPDATE_INTERVAL_MS = 500;
 const SLACK = 128;
 
@@ -161,6 +161,15 @@ events.on('user-interaction-inactive', function () {
 }, true);
 
 panel.port.on('pixelRatioChanged', function (pixelRatio) {
+  resetDevPixelsPerPx();
+
+  savePixelRatio(getActiveScreen(), pixelRatio);
+  console.log('saved pixelRatio', pixelRatio);
+
+  update(true);
+});
+panel.port.on('defaultRatioChanged', function (pixelRatio) {
+  DEFAULT_PIXEL_RATIO=pixelRatio;
   resetDevPixelsPerPx();
 
   savePixelRatio(getActiveScreen(), pixelRatio);


### PR DESCRIPTION
This should give more pleasent behaviour with ~scrolling~ zooming, as at least the ratio will stay the same

This is the first time I did anything with firefox extensions, but it seemed reasonably straightforward  (i didn't actually test it though since I'm at work). I can test it later, but I'd already ask you if there is anything oppsing this PR in principle (i.e. opposing the idea of changing the default)